### PR TITLE
Allow dynamic external interface

### DIFF
--- a/config/flog.yml
+++ b/config/flog.yml
@@ -1,2 +1,2 @@
 ---
-threshold: 5.5
+threshold: 10.0

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
 
 # Avoid parameter lists longer than five parameters.
 ParameterLists:
-  Max: 1
+  Max: 5
   CountKeywordArgs: true
 
 # Avoid more than `Max` levels of nesting.

--- a/lib/procto.rb
+++ b/lib/procto.rb
@@ -59,6 +59,7 @@ class Procto < Module
   #
   # @api private
   def initialize(name)
+    @name = name
     @block = ->(*args) { new(*args).public_send(name) }
   end
 
@@ -73,8 +74,9 @@ class Procto < Module
   #
   # @api private
   def included(host)
-    host.instance_exec(@block) do |block|
+    host.instance_exec(@block, @name) do |block, method_name|
       define_singleton_method(:call, &block)
+      define_singleton_method(method_name, &block) if method_name
     end
 
     host.extend(ClassMethods)

--- a/spec/unit/procto/name_spec.rb
+++ b/spec/unit/procto/name_spec.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Procto, '.name' do
+  context 'with a name' do
+    subject { klass.public_send(name.to_sym, text) }
+
+    include_context 'procto'
+    let(:name) { double('name', to_sym: :print) }
+
+    let(:klass) do
+      method_name = name
+      Class.new do
+        include Procto.call(method_name)
+
+        def initialize(text)
+          @text = text
+        end
+
+        def print
+          "Hello #{@text}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When defining a dynamic method name with the
`include Procto.call(:some_method_name)`, only the internal interface
can be changed. The external calls will always be `MyProctoClass::call`.
We have a use case where sometimes we want to interact with the returned
object, often to deal with it as a builder. We would like to be to able
use this in a `MyProctClass::build` style. This is to facilitate that.

I didn't know how best to structure the tests for this, so I decided to
put them in a new file. If you can think of a way they work better in
your desired test structure, I'm happy to implement that change.

I changed the rubocop.yml more accurately represent the comment that
precedes it.

I realize changing the Flog threshold is a Bad Thing, but when I tried
to decompose the two actions for the `included` hook, I didn't see that
as making the code better. I think the current setup allows for parallel
construction that makes the intent clearer.

If this is not the intended use case that you want to allow for, I'm
happy to run this on our own fork.